### PR TITLE
Passing signal to keepuped process

### DIFF
--- a/keepup.c
+++ b/keepup.c
@@ -38,7 +38,12 @@ int daemonize() {
   close(STDERR_FILENO);
 }
 
-void safe_exit() {
+void sigquit_safe_exit() {
+  kill(pid, SIGQUIT);
+  exit(EXIT_FAILURE);
+}
+
+void sigterm_safe_exit() {
   kill(pid, SIGTERM);
   exit(EXIT_FAILURE);
 }
@@ -66,8 +71,8 @@ int main(int argc, char **argv) {
     process = arg;
   }
 
-  signal(SIGTERM, &safe_exit);
-  signal(SIGQUIT, &safe_exit);
+  signal(SIGTERM, &sigterm_safe_exit);
+  signal(SIGQUIT, &sigquit_safe_exit);
 
   if (daemon) {
     daemonize();


### PR DESCRIPTION
Hey Rod,

Some processes may have different treatment for different signals, such as SIGQUIT and SIGTERM.
I think it is a good move for the signal processor keepuped, no?
